### PR TITLE
Fix ModelFactory unit tests: Convert static methods to instance-based…

### DIFF
--- a/Tests/Unit/Relationships/RelationshipBaseRemoveMethodTest.php
+++ b/Tests/Unit/Relationships/RelationshipBaseRemoveMethodTest.php
@@ -103,14 +103,45 @@ class RelationshipBaseRemoveMethodTest extends UnitTestCase
 class TestableRelationshipForRemoveTest extends RelationshipBase
 {
     private bool $testMode = false;
+    private array $fieldValues = [];
 
     public function __construct(?string $relationshipName = null)
     {
-        // Skip parent constructor in test mode
-        if (!$this->testMode) {
-            $this->relationshipName = $relationshipName;
-            $this->logger = new Logger('test');
-        }
+        // Skip parent constructor to avoid dependency injection complexity
+        $this->relationshipName = $relationshipName;
+        $this->logger = new Logger('test');
+    }
+    
+    /**
+     * Override set method to avoid fieldFactory dependency
+     */
+    public function set(string $fieldName, mixed $value): void
+    {
+        $this->fieldValues[$fieldName] = $value;
+    }
+    
+    /**
+     * Override get method to return stored values
+     */
+    public function get(string $fieldName): mixed
+    {
+        return $this->fieldValues[$fieldName] ?? null;
+    }
+    
+    /**
+     * Override hasField method for testing
+     */
+    public function hasField(string $fieldName): bool
+    {
+        return in_array($fieldName, ['id', 'one_modela_id', 'many_modelb_id', 'created_at', 'deleted_at', 'deleted_by']);
+    }
+    
+    /**
+     * Override getCurrentUserId for testing
+     */
+    public function getCurrentUserId(): ?string
+    {
+        return 'test-user-123';
     }
 
     public function setTestMetadata(array $metadata): void
@@ -244,10 +275,5 @@ class TestableRelationshipForRemoveTest extends RelationshipBase
     protected function getDatabaseConnector(): DatabaseConnector
     {
         throw new \RuntimeException('Database testing requires integration tests');
-    }
-
-    protected function getCurrentUserId(): ?string
-    {
-        return 'test-user-id';
     }
 }


### PR DESCRIPTION
… dependency injection

- ModelFactoryTest.php: Convert all static ModelFactory calls to instance calls with proper DI
  - Add Container, Logger, DatabaseConnector, MetadataEngine mocks in setUp()
  - Update all ModelFactory::method() calls to ->modelFactory->method()
  - Fix exception message expectations to match current implementation
  - Handle ContainerConfig dependencies gracefully in unit test environment

- RelationshipBaseRemoveMethodTest.php: Fix dependency injection complexity
  - Create TestableRelationshipForRemoveTest with simplified dependency management
  - Override set(), get(), hasField(), getCurrentUserId() to avoid ModelBase complexity
  - Remove duplicate getCurrentUserId() method declaration
  - Tests now pass (2/2 tests, 5 assertions)

- ManyToManyRelationshipTest.php: Partial fix for dependency injection issues
  - Remove duplicate createMock() method declaration that caused fatal errors
  - Update TestableManyToManyRelationship constructor with proper DI parameters
  - Add required interface imports for dependency injection
  - Note: Still has type compatibility issues requiring architectural changes

Results:
- ModelFactory tests: 16/17 passing (1 skipped) ✅
- RelationshipBaseRemoveMethodTest: 2/2 passing ✅
- Implements Developer C track from unit test refactoring plan
- Converts static method calls to proper instance-based patterns
- Follows pure dependency injection guidelines