### PR TITLE
Fix deployment package discovery issue in CI/CD pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -305,6 +305,17 @@ jobs:
         with:
           name: deployment-package-${{ needs.validate-deployment.outputs.deployment-id }}
 
+      - name: Debug - List downloaded contents
+        run: |
+          echo "📁 Contents of working directory:"
+          ls -la
+          echo "📁 Contents of packages directory (if exists):"
+          if [ -d "packages" ]; then
+            ls -la packages/
+          else
+            echo "❌ packages directory not found"
+          fi
+
       - name: Setup SSH
         run: |
           mkdir -p ~/.ssh

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,9 @@ restart-frontend.sh
 claud*config*.json*
 #Untitled*
 .phpunit.result.cache
-packages/
+# Deployment packages (contents ignored, directory preserved)
+packages/*
+!packages/.gitkeep
 # PHPUnit output and cache
 /coverage/
 /.phpunit.cache/
@@ -28,3 +30,6 @@ scripts/config/credentials.conf
 
 # Build artifacts
 build-metadata.json
+*.tar
+*.tar.gz
+*.zip

--- a/packages/.gitkeep
+++ b/packages/.gitkeep
@@ -1,0 +1,2 @@
+# This directory is used for deployment packages during CI/CD
+# The directory structure is preserved but contents are not tracked

--- a/scripts/deploy/transfer.sh
+++ b/scripts/deploy/transfer.sh
@@ -63,8 +63,21 @@ check_package() {
     local package_dir="${PROJECT_ROOT}/packages"
     local package_pattern="*${DEPLOYMENT_ID}*"
     
+    log_info "Looking for packages in: $package_dir"
+    log_info "Package pattern: $package_pattern"
+    
+    # Debug: List current directory contents
+    log_info "Current working directory: $(pwd)"
+    log_info "Project root directory: $PROJECT_ROOT"
+    log_info "Contents of project root:"
+    ls -la "$PROJECT_ROOT" || log_error "Failed to list project root"
+    
     if [ ! -d "$package_dir" ]; then
         log_error "Packages directory not found: $package_dir"
+        log_info "Creating packages directory for debugging..."
+        mkdir -p "$package_dir"
+        log_info "Directory created. Contents now:"
+        ls -la "$package_dir" || log_error "Failed to list packages directory after creation"
         exit 1
     fi
     
@@ -76,6 +89,8 @@ check_package() {
         log_error "Deployment package not found matching: $package_pattern"
         log_error "Available packages:"
         ls -la "$package_dir" || log_error "Failed to list packages directory"
+        log_error "All files in packages directory:"
+        find "$package_dir" -type f -o -type d | head -20
         exit 1
     fi
     


### PR DESCRIPTION
- Add debug information to transfer.sh script for better troubleshooting
- Create packages directory with .gitkeep to ensure it exists in repository
- Update .gitignore to preserve packages directory but ignore contents
- Add debugging step in GitHub workflow to show downloaded artifact contents
- Include additional archive file patterns in .gitignore

This resolves the 'Packages directory not found' error during deployment by ensuring the packages directory structure exists and providing better diagnostic information for troubleshooting artifact download issues.