### PR TITLE
Fix artifact download path and add fallback package discovery

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -304,6 +304,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: deployment-package-${{ needs.validate-deployment.outputs.deployment-id }}
+          path: packages/
 
       - name: Debug - List downloaded contents
         run: |


### PR DESCRIPTION
- Specify 'path: packages/' in download-artifact step to preserve directory structure
- Add fallback logic in transfer.sh to check root directory if package not found in packages/
- Automatically move packages from root to packages directory when found in wrong location
- Enhanced error reporting to show both packages directory and root directory contents

This handles both the correct artifact download path and provides fallback for cases where artifacts are extracted to unexpected locations.