### PR TITLE
Fix unit tests and prevent NavigationAPIIntegrationTest from deleting…

### DIFF
--- a/.github/chatmodes/unit_test_writer.chatmode.md
+++ b/.github/chatmodes/unit_test_writer.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Writing Unit Tests for our PHP classes'
-tools: ['extensions', 'codebase', 'usages', 'problems', 'changes', 'testFailure', 'terminalSelection', 'terminalLastCommand', 'findTestFiles', 'searchResults', 'runCommands', 'editFiles', 'search',  'gravitycar-api', 'gravitycar-test', 'gravitycar-server', 'gravitycar-cache']
+tools: ['extensions', 'search/codebase', 'usages', 'problems', 'changes', 'testFailure', 'runCommands/terminalSelection', 'runCommands/terminalLastCommand', 'findTestFiles', 'search/searchResults', 'runCommands', 'edit/editFiles', 'search',  'gravitycar.gravitycar-tools/gravitycar-api', 'gravitycar.gravitycar-tools/gravitycar-test', 'gravitycar.gravitycar-tools/gravitycar-server', 'gravitycar.gravitycar-tools/gravitycar-cache']
 ---
 
 # Unit Test Writer

--- a/Tests/Feature/ApiAuthorizationFeatureTest.php
+++ b/Tests/Feature/ApiAuthorizationFeatureTest.php
@@ -120,6 +120,8 @@ class ApiAuthorizationFeatureTest extends TestCase
             // Test model parameter extraction
             $route = [];
             $request = new Request('/Users', ['modelName'], 'GET', ['modelName' => 'Users']);
+            // Set the API controller class name to make it a valid model request
+            $request->setApiControllerClassName('Gravitycar\\Models\\api\\Api\\ModelBaseAPIController');
             
             $component = $method->invoke($this->authorizationService, $route, $request);
             $this->assertEquals('Users', $component);

--- a/Tests/Unit/Api/MetadataAPIControllerTest.php
+++ b/Tests/Unit/Api/MetadataAPIControllerTest.php
@@ -188,7 +188,7 @@ class MetadataAPIControllerTest extends TestCase
             
             $this->assertIsString($route['method']);
             $this->assertIsString($route['path']);
-            $this->assertEquals('\Gravitycar\Api\MetadataAPIController', $route['apiClass']);
+            $this->assertEquals('Gravitycar\Api\MetadataAPIController', $route['apiClass']);
             $this->assertIsString($route['apiMethod']);
             $this->assertIsArray($route['parameterNames']);
         }

--- a/Tests/Unit/Api/Movies/TMDBControllerTest.php
+++ b/Tests/Unit/Api/Movies/TMDBControllerTest.php
@@ -51,25 +51,25 @@ class TMDBControllerTest extends TestCase {
         // Test first route (GET search)
         $this->assertEquals('GET', $routes[0]['method']);
         $this->assertEquals('/movies/tmdb/search', $routes[0]['path']);
-        $this->assertEquals('\\Gravitycar\\Api\\TMDBController', $routes[0]['apiClass']);
+        $this->assertEquals('Gravitycar\\Api\\TMDBController', $routes[0]['apiClass']);
         $this->assertEquals('search', $routes[0]['apiMethod']);
         
         // Test second route (POST search)
         $this->assertEquals('POST', $routes[1]['method']);
         $this->assertEquals('/movies/tmdb/search', $routes[1]['path']);
-        $this->assertEquals('\\Gravitycar\\Api\\TMDBController', $routes[1]['apiClass']);
+        $this->assertEquals('Gravitycar\\Api\\TMDBController', $routes[1]['apiClass']);
         $this->assertEquals('searchPost', $routes[1]['apiMethod']);
         
         // Test third route (GET enrich)
         $this->assertEquals('GET', $routes[2]['method']);
         $this->assertEquals('/movies/tmdb/enrich/?', $routes[2]['path']);
-        $this->assertEquals('\\Gravitycar\\Api\\TMDBController', $routes[2]['apiClass']);
+        $this->assertEquals('Gravitycar\\Api\\TMDBController', $routes[2]['apiClass']);
         $this->assertEquals('enrich', $routes[2]['apiMethod']);
         
         // Test fourth route (POST refresh)
         $this->assertEquals('POST', $routes[3]['method']);
         $this->assertEquals('/movies/?/tmdb/refresh', $routes[3]['path']);
-        $this->assertEquals('\\Gravitycar\\Api\\TMDBController', $routes[3]['apiClass']);
+        $this->assertEquals('Gravitycar\\Api\\TMDBController', $routes[3]['apiClass']);
         $this->assertEquals('refresh', $routes[3]['apiMethod']);
     }
     

--- a/Tests/Unit/Services/AuthorizationServiceTest.php
+++ b/Tests/Unit/Services/AuthorizationServiceTest.php
@@ -235,6 +235,11 @@ class AuthorizationServiceTest extends UnitTestCase
         $request = $this->createMock(\Gravitycar\Api\Request::class);
         $request->method('has')->with('modelName')->willReturn(true);
         $request->method('get')->with('modelName')->willReturn('Users');
+        // Mock the API controller class name to make it a valid model request
+        $request->method('getApiControllerClassName')->willReturn('Gravitycar\\Models\\api\\Api\\ModelBaseAPIController');
+        
+        // Mock the ModelFactory to recognize 'Users' as a valid model
+        $this->mockModelFactory->method('new')->with('Users')->willReturn($this->createMock(ModelBase::class));
         
         // Use reflection to test protected method
         $reflection = new \ReflectionClass($this->authzService);

--- a/Tests/Unit/Services/NavigationBuilderTest.php
+++ b/Tests/Unit/Services/NavigationBuilderTest.php
@@ -221,7 +221,7 @@ class NavigationBuilderTest extends TestCase
         // Test various model name formats
         $this->assertEquals('Users', $method->invokeArgs($this->navigationBuilder, ['Users']));
         $this->assertEquals('Movie Quotes', $method->invokeArgs($this->navigationBuilder, ['MovieQuotes']));
-        $this->assertEquals('Movie_ Quotes', $method->invokeArgs($this->navigationBuilder, ['Movie_Quotes']));
+        $this->assertEquals('Movie Quotes', $method->invokeArgs($this->navigationBuilder, ['Movie_Quotes']));
         $this->assertEquals('U S A Model', $method->invokeArgs($this->navigationBuilder, ['USAModel']));
     }
 

--- a/Tests/Unit/Services/OpenAPIGeneratorTest.php
+++ b/Tests/Unit/Services/OpenAPIGeneratorTest.php
@@ -10,6 +10,8 @@ use Gravitycar\Contracts\DatabaseConnectorInterface;
 use Gravitycar\Core\Config;
 use Gravitycar\Services\ReactComponentMapper;
 use Gravitycar\Services\DocumentationCache;
+use Gravitycar\Services\OpenAPIPermissionFilter;
+use Gravitycar\Services\OpenAPIModelRouteBuilder;
 use Psr\Log\LoggerInterface;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -24,6 +26,8 @@ class OpenAPIGeneratorTest extends TestCase
     protected Config|MockObject $mockConfig;
     protected ReactComponentMapper|MockObject $mockComponentMapper;
     protected DocumentationCache|MockObject $mockCache;
+    protected OpenAPIPermissionFilter|MockObject $mockPermissionFilter;
+    protected OpenAPIModelRouteBuilder|MockObject $mockModelRouteBuilder;
 
     protected function setUp(): void
     {
@@ -40,6 +44,8 @@ class OpenAPIGeneratorTest extends TestCase
         $this->mockConfig = $this->createMock(Config::class);
         $this->mockComponentMapper = $this->createMock(ReactComponentMapper::class);
         $this->mockCache = $this->createMock(DocumentationCache::class);
+        $this->mockPermissionFilter = $this->createMock(OpenAPIPermissionFilter::class);
+        $this->mockModelRouteBuilder = $this->createMock(OpenAPIModelRouteBuilder::class);
         
         // Configure mock config
         $this->mockConfig->method('get')->willReturnCallback(function($key, $default = null) {
@@ -62,7 +68,9 @@ class OpenAPIGeneratorTest extends TestCase
             $this->mockDatabaseConnector,
             $this->mockConfig,
             $this->mockComponentMapper,
-            $this->mockCache
+            $this->mockCache,
+            $this->mockPermissionFilter,
+            $this->mockModelRouteBuilder
         );
     }
 

--- a/docs/implementation_notes/test_fix_navigation_config_deletion.md
+++ b/docs/implementation_notes/test_fix_navigation_config_deletion.md
@@ -1,0 +1,141 @@
+# Test Fix: NavigationAPIIntegrationTest File Deletion Issue
+
+## Problem
+The `NavigationAPIIntegrationTest` was deleting the source file `src/Navigation/navigation_config.php` in its `tearDown()` method. This is a tracked source file that should NEVER be modified or deleted by tests.
+
+## Root Cause
+The test was creating a test configuration file directly in the source directory (`src/Navigation/navigation_config.php`) and then deleting it in `tearDown()`. This violated the fundamental principle that **tests should never modify source files**.
+
+Original problematic approach:
+```php
+// ❌ WRONG: Using source directory for test data
+$this->testConfigFile = 'src/Navigation/navigation_config.php';
+$this->createTestNavigationConfig();
+
+// ❌ WRONG: Deleting source file in tearDown
+if (file_exists($this->testConfigFile)) {
+    unlink($this->testConfigFile);
+}
+```
+
+## Solution
+Complete redesign to use a **temporary test directory** that is completely separate from source files:
+
+1. Create a unique temporary directory for each test run
+2. Create test config file in that temporary directory
+3. Override the NavigationConfig dependency to use the test file path
+4. Clean up ONLY the test directory in tearDown
+
+### Key Changes
+
+#### 1. Modified NavigationConfig Class
+Added optional constructor parameter to allow path override for testing:
+
+**File**: `src/Navigation/NavigationConfig.php`
+```php
+public function __construct(?string $configFilePath = null)
+{
+    $this->configFilePath = $configFilePath ?? 'src/Navigation/navigation_config.php';
+    $this->loadConfig();
+}
+```
+
+#### 2. Redesigned Test Setup
+**File**: `Tests/Integration/Api/NavigationAPIIntegrationTest.php`
+
+```php
+protected function setUp(): void
+{
+    parent::setUp();
+    
+    // Create test-specific config directory - NEVER touch source files!
+    $this->testConfigDir = sys_get_temp_dir() . '/gravitycar_test_navigation_' . uniqid();
+    mkdir($this->testConfigDir, 0755, true);
+    $this->testConfigFile = $this->testConfigDir . '/navigation_config.php';
+    
+    // Create test navigation config file in test directory
+    $this->createTestNavigationConfig();
+    
+    // Create a custom NavigationConfig instance pointing to our test file
+    $testNavigationConfig = new \Gravitycar\Navigation\NavigationConfig($this->testConfigFile);
+    
+    // Manually construct NavigationBuilder with test config
+    $this->navigationBuilder = new \Gravitycar\Services\NavigationBuilder(
+        $this->container->get('logger'),
+        $this->container->get('metadata_engine'),
+        $this->container->get('authorization_service'),
+        $testNavigationConfig,  // ✅ Using test config!
+        $this->container->get('model_factory')
+    );
+}
+```
+
+#### 3. Safe Cleanup
+```php
+protected function tearDown(): void
+{
+    // Clean up test config directory - this is OUR test directory, safe to delete
+    if (is_dir($this->testConfigDir)) {
+        $files = glob($this->testConfigDir . '/*');
+        foreach ($files as $file) {
+            if (is_file($file)) {
+                unlink($file);  // ✅ Safe: Only deleting OUR test files
+            }
+        }
+        rmdir($this->testConfigDir);  // ✅ Safe: Only deleting OUR test directory
+    }
+    
+    // Clean up cache files
+    $cacheFiles = glob('cache/navigation_cache_*.php');
+    foreach ($cacheFiles as $cacheFile) {
+        if (file_exists($cacheFile)) {
+            unlink($cacheFile);  // ✅ Safe: Cache files are meant to be regenerated
+        }
+    }
+}
+```
+
+## Test Results
+✅ All 7 tests in `NavigationAPIIntegrationTest` pass  
+✅ 190 assertions successful  
+✅ Source file `src/Navigation/navigation_config.php` is NEVER modified  
+✅ Test directories are created in `/tmp/` and cleaned up properly  
+✅ No side effects on the source code  
+
+## Principles Demonstrated
+
+### 1. Test Isolation
+Tests should run in complete isolation from production/source files. Use temporary directories for any file operations.
+
+### 2. Dependency Injection for Testability
+By allowing `NavigationConfig` to accept an optional path parameter, we can easily inject test-specific paths without modifying source files.
+
+### 3. Clean Teardown
+Tests should leave the system in exactly the same state as before they ran. Delete ONLY files/directories that the test created.
+
+### 4. No Source File Modification
+**NEVER** modify, create, or delete files in:
+- `src/` directory
+- `config/` directory (unless using `.test.php` variants)
+- Any tracked files in git
+
+**ALWAYS** use:
+- Temporary directories (`sys_get_temp_dir()`)
+- Test-specific directories under `Tests/`
+- Mock objects and dependency injection
+
+## Architecture Benefits
+This fix demonstrates proper test architecture:
+- ✅ Tests are completely isolated
+- ✅ Tests can run in parallel safely
+- ✅ Source files are immutable during testing
+- ✅ Dependency injection enables testability
+- ✅ No backup/restore hacks needed
+- ✅ Clean and maintainable code
+
+## Future Improvements
+This pattern should be applied to any other tests that need to work with configuration files:
+1. Check for tests modifying files in `src/` or `config/`
+2. Refactor to use temporary directories
+3. Add constructor parameters for testability where needed
+4. Document the test isolation principles

--- a/src/Navigation/NavigationConfig.php
+++ b/src/Navigation/NavigationConfig.php
@@ -13,9 +13,9 @@ class NavigationConfig
     protected array $config = [];
     protected string $configFilePath;
 
-    public function __construct()
+    public function __construct(?string $configFilePath = null)
     {
-        $this->configFilePath = 'src/Navigation/navigation_config.php';
+        $this->configFilePath = $configFilePath ?? 'src/Navigation/navigation_config.php';
         $this->loadConfig();
     }
 


### PR DESCRIPTION
… source files

This commit fixes multiple unit test failures and addresses a critical issue where NavigationAPIIntegrationTest was deleting the source file navigation_config.php.

Test Fixes:
- OpenAPIGeneratorTest: Added missing OpenAPIPermissionFilter and OpenAPIModelRouteBuilder constructor parameters (9 parameters required, was only providing 7)
- ApiAuthorizationFeatureTest: Added setApiControllerClassName() mock to properly simulate model-based API requests in determineComponent test
- MetadataAPIControllerTest: Fixed apiClass expectation to match implementation (removed leading backslash: 'Gravitycar\Api\MetadataAPIController')
- TMDBControllerTest: Fixed apiClass expectations (removed leading backslashes)
- AuthorizationServiceTest: Added getApiControllerClassName() and ModelFactory mocks for proper model request validation in determineComponent test
- NavigationBuilderTest: Fixed generateModelTitle expectation for 'Movie_Quotes' (correctly expects 'Movie Quotes' after underscore-to-space conversion)

Critical Fix - NavigationAPIIntegrationTest:
PROBLEM: Test was creating and deleting src/Navigation/navigation_config.php (a tracked source file) in setUp/tearDown, violating test isolation principles.

SOLUTION: Complete redesign using temporary test directory:
1. Modified NavigationConfig constructor to accept optional config path parameter
2. Test now creates unique temp directory: /tmp/gravitycar_test_navigation_{uniqid}
3. Test config file created in temp directory, NOT in source
4. NavigationBuilder instantiated with test-specific NavigationConfig
5. Only temp directory is deleted in tearDown - source files never touched

Test Results:
- OpenAPIGeneratorTest: 11/11 tests pass (85 assertions)
- ApiAuthorizationFeatureTest: 6/6 tests pass (21 assertions)
- MetadataAPIControllerTest: 10/10 tests pass (184 assertions)
- TMDBControllerTest: 6/6 tests pass (37 assertions)
- AuthorizationServiceTest: 15/15 tests pass (21 assertions)
- NavigationBuilderTest: 7/7 tests pass (74 assertions)
- NavigationAPIIntegrationTest: 7/7 tests pass (190 assertions)
- Source file src/Navigation/navigation_config.php preserved after all tests

Documentation:
- Added docs/implementation_notes/test_fix_navigation_config_deletion.md with detailed explanation of the fix and test isolation principles