### PR TITLE
Fix ESLint errors and add validate script

### DIFF
--- a/gravitycar-frontend/package.json
+++ b/gravitycar-frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "validate": "npm run lint && npm run build",
     "preview": "vite preview",
     "kill-port": "./scripts/kill-port-3000.sh",
     "restart": "./scripts/restart-dev-server.sh"

--- a/gravitycar-frontend/src/components/crud/GenericCrudPage.tsx
+++ b/gravitycar-frontend/src/components/crud/GenericCrudPage.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState, useEffect } from 'react';
-import { useLocation, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { useNotify } from '../../contexts/NotificationContext';
 import { useModelMetadata } from '../../hooks/useModelMetadata';
 import { apiService } from '../../services/api';

--- a/gravitycar-frontend/src/components/navigation/NavigationSidebar.tsx
+++ b/gravitycar-frontend/src/components/navigation/NavigationSidebar.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { navigationService } from '../../services/navigationService';
-import { NavigationData, NavigationItem, NavigationAction } from '../../types/navigation';
+import { NavigationData, NavigationAction } from '../../types/navigation';
 import { useAuth } from '../../hooks/useAuth';
 
 interface NavigationSidebarProps {

--- a/gravitycar-frontend/src/components/navigation/__tests__/NavigationSidebar.test.tsx
+++ b/gravitycar-frontend/src/components/navigation/__tests__/NavigationSidebar.test.tsx
@@ -210,6 +210,7 @@ describe('NavigationSidebar', () => {
   it('shows debug info in development mode', async () => {
     // Mock development environment
     const originalEnv = import.meta.env.DEV;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (import.meta.env as any).DEV = true;
 
     render(<NavigationSidebar />);
@@ -223,6 +224,7 @@ describe('NavigationSidebar', () => {
     expect(screen.getByText('Model Permissions')).toBeInTheDocument();
 
     // Restore environment
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (import.meta.env as any).DEV = originalEnv;
   });
 

--- a/gravitycar-frontend/src/services/navigationService.ts
+++ b/gravitycar-frontend/src/services/navigationService.ts
@@ -19,6 +19,7 @@ class NavigationService {
 
     try {
       // Use the apiService's internal axios instance pattern
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const response = await (apiService as any).api.get('/navigation');
       const navigationData = response.data as NavigationResponse;
 
@@ -46,6 +47,7 @@ class NavigationService {
 
     try {
       // Use the apiService's internal axios instance pattern
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const response = await (apiService as any).api.get(`/navigation/${role}`);
       const navigationData = response.data as NavigationResponse;
 
@@ -66,6 +68,7 @@ class NavigationService {
   async rebuildNavigationCache(): Promise<NavigationResponse> {
     try {
       // Use the apiService's internal axios instance pattern
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const response = await (apiService as any).api.post('/navigation/cache/rebuild');
       const result = response.data as NavigationResponse;
       


### PR DESCRIPTION
Fixed 7 ESLint errors that were blocking deployment:

1. GenericCrudPage.tsx: Removed unused 'useLocation' import
2. NavigationSidebar.tsx: Removed unused 'NavigationItem' import
3. NavigationSidebar.test.tsx: Added inline eslint-disable comments for unavoidable 'any' types when mocking import.meta.env
4. navigationService.ts: Added inline eslint-disable comments for 3 unavoidable 'any' types when accessing internal apiService.api

Added 'validate' npm script to package.json that runs both ESLint and build checks. This script should be run before deployment to catch linting and build errors locally:

  npm run validate

This prevents deployment failures by ensuring all code quality checks pass before pushing to CI/CD pipeline.