### PR TITLE
fix: wrap case 401 block in braces to resolve ESLint no-case-declarat…

### DIFF
--- a/gravitycar-frontend/src/services/api.ts
+++ b/gravitycar-frontend/src/services/api.ts
@@ -88,7 +88,7 @@ class ApiService {
           case 400:
             message = 'Bad request. Please check your input.';
             break;
-          case 401:
+          case 401: {
             // Check if it's a session expiration
             const sessionExpired = error.response.data?.message?.includes('inactivity') || 
                                    error.response.data?.code === 'SESSION_EXPIRED';
@@ -104,6 +104,7 @@ class ApiService {
             localStorage.removeItem('user');
             window.location.href = '/login';
             break;
+          }
           case 403:
             message = 'Access denied. You don\'t have permission for this action.';
             break;


### PR DESCRIPTION
…ions error

Fix ESLint error 'Unexpected lexical declaration in case block' by wrapping the case 401 block in braces. This creates proper block scope for the 'sessionExpired' const declaration, which is required by the no-case-declarations rule.

The session expiration detection logic remains unchanged - this is purely a code style fix to satisfy linting requirements.