### PR TITLE
Fix infinite loop in inactivity session timeout by using DatabaseConn…

### DIFF
--- a/src/Core/ContainerConfig.php
+++ b/src/Core/ContainerConfig.php
@@ -313,6 +313,7 @@ class ContainerConfig {
             'authService' => $di->lazyGet('authentication_service'),
             'modelFactory' => $di->lazyGet('model_factory'),
             'config' => $di->lazyGet('config'),
+            'databaseConnector' => $di->lazyGet('database_connector'),
             'guestUserManager' => null // Will be created internally if needed
         ];
 


### PR DESCRIPTION
…ector directly

This commit resolves a critical circular dependency bug that caused infinite loops when updating user activity timestamps during authentication checks.

## Problem
When a user made an API request with a valid JWT token:
1. Router → getCurrentUser() → checks inactivity timeout
2. updateLastActivity() → $user->update()
3. ModelBase::update() → setAuditFieldsForUpdate()
4. setAuditFieldsForUpdate() → getCurrentUserId()
5. getCurrentUserId() → getCurrentUser() [INFINITE LOOP - back to step 1]

Xdebug detected the infinite loop after 512 stack frames, causing 500 errors.

## Solution
Changed CurrentUserProvider::updateLastActivity() to bypass ModelBase::update() and call DatabaseConnector::update() directly. This low-level method extracts field data and builds SQL without triggering audit field logic, breaking the cycle.

## Changes Made

### src/Services/CurrentUserProvider.php
- Added DatabaseConnectorInterface dependency injection (5th constructor param)
- Updated updateLastActivity() to call $this->databaseConnector->update($user)
- Added detailed documentation explaining why direct DatabaseConnector usage is needed
- Maintains proper framework patterns (no raw SQL)

### src/Core/ContainerConfig.php
- Added 'databaseConnector' => $di->lazyGet('database_connector') to CurrentUserProvider DI params
- Ensures DatabaseConnector is properly injected when CurrentUserProvider is instantiated

### Tests/Unit/Services/InactivitySessionTimeoutTest.php
- Added DatabaseConnectorInterface import and mock property
- Created mock DatabaseConnector in setUp() method
- Updated createProvider() to pass mock DatabaseConnector instead of null
- Changed all test expectations from $mockUser->update() to $mockDatabaseConnector->update($mockUser)
- All 7 inactivity timeout tests now passing

## Testing
- All 1268 tests passing (unit + integration + feature)
- Verified fix works in production: successful authentication at 17:24:00 with no errors
- Confirmed DatabaseConnector::update() bypasses ModelBase audit trail as intended

## Technical Notes
- DatabaseConnector::update() is the correct solution per framework patterns
- Avoids raw SQL while still bypassing the circular dependency
- Audit trail still functions normally for all other model updates
- Activity timestamp debouncing (60s) still works correctly